### PR TITLE
Docker Compose for easier local dev env deployment

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,0 +1,69 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:18-alpine
+    container_name: musictaste-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-musictaste}
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+    ports:
+      - '${DB_PORT:-5432}:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${DB_USERNAME:-postgres}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:8-alpine
+    container_name: musictaste-redis
+    restart: unless-stopped
+    ports:
+      - '${REDIS_PORT:-6379}:6379'
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:latest
+    container_name: musictaste-minio
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY:-minioadmin}
+    ports:
+      - '9000:9000' # API
+      - '9001:9001' # Console UI
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: musictaste-mailpit
+    restart: unless-stopped
+    ports:
+      - '1025:1025' # SMTP
+      - '8025:8025' # Web UI
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  minio_data:
+    driver: local


### PR DESCRIPTION
Hi!
I just found your project on Twitter, and have had the idea to do a similar thing for quite some time now - didn't take the time to do it yet though. Thanks for the initiative haha.

I noticed a simple bug I could fix on the frontend, and while setting up the repo, it didn't seem to have any local dev env services in place.

Usually I use Docker for services like PG and Redis.
I basically took the config from one of my projects and simplified it, which permits to run the Compose stack and have all the external services ready for API dev!

This might not be your preferred way of doing things, and I am expecting to need to add other changes (like docs for instance). For now this was easy and quick enough to just drop this PR and ask for your guidance! It'll help me get familiar with the codebase in the meantime.

Again thanks for this initiative and great project, can't wait to see it expand!