### PR TITLE
Fix form data helper

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -18,8 +18,8 @@ REDIS_PASS=
 # AWS S3 (Minio for local development)
 AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin
-AWS_BUCKET_NAME=us-east-1
-AWS_REGION=musictaste
+AWS_BUCKET_NAME=musictaste
+AWS_REGION=us-east-1
 AWS_ENDPOINT=http://127.0.0.1:9000
 CDN_URL=http://127.0.0.1:9000/musictaste/
 

--- a/web/src/utils/build-form-data.ts
+++ b/web/src/utils/build-form-data.ts
@@ -1,5 +1,29 @@
-import { toFormData } from 'axios';
+const appendToFormData = (
+  formData: FormData,
+  key: string,
+  value: any,
+): void => {
+  if (value == null) return;
+
+  if (value instanceof File) {
+    formData.append(key, value);
+  } else if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      appendToFormData(formData, `${key}[${index}]`, item),
+    );
+  } else if (typeof value === 'object') {
+    Object.entries(value).forEach(([subKey, subValue]) =>
+      appendToFormData(formData, `${key}[${subKey}]`, subValue),
+    );
+  } else {
+    formData.append(key, String(value));
+  }
+};
 
 export const buildFormData = (data: Record<string, any>): FormData => {
-  return toFormData(data) as FormData;
+  const formData = new FormData();
+  Object.entries(data).forEach(([key, value]) =>
+    appendToFormData(formData, key, value),
+  );
+  return formData;
 };


### PR DESCRIPTION
As discussed on Discord a couple of days ago, I was able to confirm the previous userland implementation would've worked fine with a simple change - reverted to it with that change.

Axios uses a similar procedure, the custom one should be fine though. For more complex FormData usage, a serializer and/or more refined schemas and streamlined API usage would probably be better anyway. Would happily discuss this later on.

For now this removes a significant 40k from the bundle size!