### PR TITLE
fix: rating popup closing when grabbing bar & releasing out of popup

### DIFF
--- a/api/src/search/search.service.ts
+++ b/api/src/search/search.service.ts
@@ -28,7 +28,15 @@ export class SearchService {
     page,
     pageSize,
   }: SearchDto): Promise<ISearchResponse> {
-    const q = query.trim();
+    const normalizeQuery = (q: string) => {
+      q = q.toLowerCase();
+      q = q.replace(/[^\w\s]/g, '');
+      q = q.replace(/\s+/g, ' ');
+      q = q.trim();
+      return q;
+    };
+
+    const q = normalizeQuery(query);
     const curPageSize = pageSize || 10;
     const take = (page || 1) * curPageSize;
     const skip = ((page || 1) - 1) * curPageSize;

--- a/api/src/search/search.service.ts
+++ b/api/src/search/search.service.ts
@@ -28,15 +28,8 @@ export class SearchService {
     page,
     pageSize,
   }: SearchDto): Promise<ISearchResponse> {
-    const normalizeQuery = (q: string) => {
-      q = q.toLowerCase();
-      q = q.replace(/[^\w\s]/g, '');
-      q = q.replace(/\s+/g, ' ');
-      q = q.trim();
-      return q;
-    };
-
-    const q = normalizeQuery(query);
+    
+    const q = query.trim();
     const curPageSize = pageSize || 10;
     const take = (page || 1) * curPageSize;
     const skip = ((page || 1) - 1) * curPageSize;

--- a/web/src/features/releases/release-actions/rating-action.tsx
+++ b/web/src/features/releases/release-actions/rating-action.tsx
@@ -213,17 +213,6 @@ export const RatingAction: React.FC<{
 
   const isRated = !!entry?.rating;
   
-  useEffect(() => {
-    if (!isDragging) return;
-    const handleGlobalMouseUp = () => setTimeout(() => setIsDragging(false), 0);
-    window.addEventListener('mouseup', handleGlobalMouseUp);
-    window.addEventListener('touchend', handleGlobalMouseUp);
-    return () => {
-      window.removeEventListener('mouseup', handleGlobalMouseUp);
-      window.removeEventListener('touchend', handleGlobalMouseUp);
-    };
-  }, [isDragging]);
-
   const handleClose = () => {
     if (!isDragging) {
       setOpen(false);

--- a/web/src/features/releases/release-actions/rating-action.tsx
+++ b/web/src/features/releases/release-actions/rating-action.tsx
@@ -117,6 +117,15 @@ export const RatingPopoverContent: React.FC<{
           renderTrack={({ props, children }) => (
             <div
               {...props}
+              // Records input anywhere on rating bar
+              onMouseDown={(e) => {
+                props.onMouseDown?.(e);
+                onDragStart?.();
+              }}
+              onTouchStart={(e) => {
+                props.onTouchStart?.(e);
+                onDragStart?.();
+              }}
               style={{
                 ...props.style,
                 height: '6px',
@@ -136,9 +145,15 @@ export const RatingPopoverContent: React.FC<{
                 width: '20px',
                 backgroundColor: theme.colors.highlight,
                 border: '1px solid currentColor',
+              }} // Records input anywhere on rating bar
+              onMouseDown={(e: any) => {
+                (props as any).onMouseDown?.(e);
+                onDragStart?.();
               }}
-              onMouseDown={onDragStart}
-              onTouchStart={onDragStart}
+              onTouchStart={(e: any) => {
+                (props as any).onTouchStart?.(e);
+                onDragStart?.();
+              }}
             />
           )}
         />
@@ -197,6 +212,17 @@ export const RatingAction: React.FC<{
   const [isDragging, setIsDragging] = useState(false);
 
   const isRated = !!entry?.rating;
+  
+  useEffect(() => {
+    if (!isDragging) return;
+    const handleGlobalMouseUp = () => setTimeout(() => setIsDragging(false), 0);
+    window.addEventListener('mouseup', handleGlobalMouseUp);
+    window.addEventListener('touchend', handleGlobalMouseUp);
+    return () => {
+      window.removeEventListener('mouseup', handleGlobalMouseUp);
+      window.removeEventListener('touchend', handleGlobalMouseUp);
+    };
+  }, [isDragging]);
 
   const handleClose = () => {
     if (!isDragging) {

--- a/web/src/features/search/search-page-wrapper.tsx
+++ b/web/src/features/search/search-page-wrapper.tsx
@@ -12,16 +12,19 @@ export type SearchPageOutletContext = {
 const SearchPageWrapper: React.FC = () => {
   const [params, setParams] = useSearchParams();
 
-  const q = params.get('q') || '';
+  const [q, setQ] = useState(params.get('q') || '');
   const debouncedValue = useDebounce(q, 300);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value; // grab text from current field
-    if (value) {
-      setParams({ q: value }, { replace: true });
+  useEffect(() => {
+    if (debouncedValue) {
+      setParams({ q: debouncedValue });
     } else {
       setParams({});
     }
+  }, [debouncedValue, setParams]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQ(e.target.value);
   };
 
   return (

--- a/web/src/features/search/search-page-wrapper.tsx
+++ b/web/src/features/search/search-page-wrapper.tsx
@@ -12,19 +12,16 @@ export type SearchPageOutletContext = {
 const SearchPageWrapper: React.FC = () => {
   const [params, setParams] = useSearchParams();
 
-  const [q, setQ] = useState(params.get('q') || '');
+  const q = params.get('q') || '';
   const debouncedValue = useDebounce(q, 300);
 
-  useEffect(() => {
-    if (debouncedValue) {
-      setParams({ q: debouncedValue });
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value; // grab text from current field
+    if (value) {
+      setParams({ q: value }, { replace: true });
     } else {
       setParams({});
     }
-  }, [debouncedValue, setParams]);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setQ(e.target.value);
   };
 
   return (


### PR DESCRIPTION
Before: Grabbing rating bar from the shaft/bar and releasing outside of the popup window would close the popup and negate the input
<img width="1280" height="552" alt="bug2" src="https://github.com/user-attachments/assets/9f748d97-38fd-4f5d-a35a-d563731dbda8" />


After: Allowing for the whole bar's state to be read, this action now works for both release page and the individual popups upon clicking the 3 dots. 
<img width="1280" height="552" alt="Screen Recording 2026-04-28 at 4 27 28 PM" src="https://github.com/user-attachments/assets/0ac5c1e9-22ef-4c26-be9e-b45ecd7d4f8d" />
