### PR TITLE
fix(reviews): display negative net votes properly when not logged in

### DIFF
--- a/web/src/features/reviews/review.tsx
+++ b/web/src/features/reviews/review.tsx
@@ -69,7 +69,8 @@ const ReviewActions = ({
     return (
       <Group gap="sm">
         <Group gap="sm">
-          <IconArrowUp />+{netVotes}
+          <IconArrowUp />
+          <Typography>{netVotes > 0 ? `+${netVotes}` : netVotes}</Typography>
         </Group>
         <IconButton
           title="Comments"
@@ -78,17 +79,6 @@ const ReviewActions = ({
         >
           <IconMessage />
         </IconButton>
-        {/* {netVotes > 0 ? (
-          <Group gap="sm">
-            <IconArrowUp />
-        +{netVotes}
-          </Group>
-        ) : (
-          <Group gap="sm">
-            <IconArrowDown />
-            {netVotes}
-          </Group>
-        )} */}
       </Group>
     );
 


### PR DESCRIPTION
before this, a review score of `-2` would be formatted as `-2` when logged in, but as `+-2` when logged out